### PR TITLE
python: define config option for bluetooth support

### DIFF
--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -67,6 +67,11 @@ download_sdk() {
 # test_package will run on the `script` step.
 # test_package call make download check for very new/modified package
 test_packages2() {
+	if [ "$TRAVIS_PULL_REQUEST" = false ]; then
+		echo_blue "Using only the latest commit, since we're not in a Pull Request"
+		TRAVIS_COMMIT_RANGE=HEAD~1
+	fi
+
 	# search for new or modified packages. PKGS will hold a list of package like 'admin/muninlite admin/monit ...'
 	PKGS=$(git diff --diff-filter=d --name-only "$TRAVIS_COMMIT_RANGE" | grep 'Makefile$' | grep -v '/files/' | awk -F'/Makefile' '{ print $1 }')
 
@@ -142,6 +147,10 @@ EOF
 
 test_commits() {
 	RET=0
+	if [ "$TRAVIS_PULL_REQUEST" = false ]; then
+		echo_blue "Skipping commits tests (not in a Pull Request)"
+		return 0
+	fi
 	for commit in $(git rev-list ${TRAVIS_COMMIT_RANGE/.../..}); do
 		echo_blue "=== Checking commit '$commit'"
 		if git show --format='%P' -s $commit | grep -qF ' '; then
@@ -186,19 +195,20 @@ echo_blue "=== Travis ENV"
 env
 echo_blue "=== Travis ENV"
 
-while true; do
-	# if clone depth is too small, git rev-list / diff return incorrect or empty results
-	C="$(git rev-list ${TRAVIS_COMMIT_RANGE/.../..} | tail -n1)" 2>/dev/null
-	[ -n "$C" -a "$C" != "a22de9b74cf9579d1ce7e6cf1845b4afa4277b00" ] && break
-	echo_blue "Fetching 50 commits more"
-	git fetch origin --deepen=50
-done
-
-if [ "$TRAVIS_PULL_REQUEST" = false ] ; then
-	echo "Only Pull Requests are supported at the moment." >&2
-	exit 0
+if [ -z "$TRAVIS_COMMIT_RANGE" ] && [ "$TRAVIS_PULL_REQUEST" = true ] ; then
+	echo_red "TRAVIS_COMMIT_RANGE variable is empty in a Pull Request"
+	exit 1
 fi
 
+if [ "$TRAVIS_PULL_REQUEST" = true ]; then
+	while true; do
+		# if clone depth is too small, git rev-list / diff return incorrect or empty results
+		C="$(git rev-list ${TRAVIS_COMMIT_RANGE/.../..} | tail -n1)" 2>/dev/null
+		[ -n "$C" -a "$C" != "a22de9b74cf9579d1ce7e6cf1845b4afa4277b00" ] && break
+		echo_blue "Fetching 50 commits more"
+		git fetch origin --deepen=50
+	done
+fi
 
 if [ $# -ne 1 ] ; then
 	cat <<EOF

--- a/lang/python/python/Config-python-light.in
+++ b/lang/python/python/Config-python-light.in
@@ -1,0 +1,7 @@
+menu "Configuration"
+
+config PYTHON_BLUETOOTH_SUPPORT
+	bool "Enable Bluetooth support"
+	default n
+
+endmenu

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -14,7 +14,7 @@ PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -39,9 +39,9 @@ HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_python-setuptools CONFIG_PACKAGE_python-pip \
-	CONFIG_PACKAGE_bluez-libs
+	CONFIG_PYTHON_BLUETOOTH_SUPPORT
 
-PKG_BUILD_DEPENDS:=python/host PACKAGE_bluez-libs:bluez-libs
+PKG_BUILD_DEPENDS:=python/host
 HOST_BUILD_DEPENDS:=bzip2/host expat/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -89,7 +89,11 @@ endef
 define Package/python-light
 $(call Package/python/Default)
   TITLE:=Python $(PYTHON_VERSION) light installation
-  DEPENDS:=+python-base +libffi +libbz2 +PACKAGE_bluez-libs:bluez-libs
+  DEPENDS:=+python-base +libffi +libbz2 +PYTHON_BLUETOOTH_SUPPORT:bluez-libs
+endef
+
+define Package/python-light/config
+  source "$(SOURCE)/Config-python-light.in"
 endef
 
 define Package/python-light/description
@@ -150,6 +154,10 @@ PYTHON_FOR_BUILD:= \
 	_PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata \
 	$(HOST_PYTHON_BIN)
 
+DISABLE_BLUETOOTH:= \
+    ac_cv_header_bluetooth_bluetooth_h=no \
+    ac_cv_header_bluetooth_h=no
+
 CONFIGURE_ARGS+= \
 	--sysconfdir=/etc \
 	--enable-shared \
@@ -158,6 +166,7 @@ CONFIGURE_ARGS+= \
 	--with-system-ffi \
 	--with-ensurepip=no \
 	--without-pymalloc \
+	$(if $(CONFIG_PYTHON_BLUETOOTH_SUPPORT),,$(DISABLE_BLUETOOTH)) \
 	PYTHON_FOR_BUILD="$(PYTHON_FOR_BUILD)" \
 	$(ENABLE_IPV6) \
 	CONFIG_SITE="$(PKG_BUILD_DIR)/config.site" \


### PR DESCRIPTION
It was reported via
https://github.com/openwrt/packages/pull/5122#issuecomment-347395472
that if bluez-libs is selected as an installable package,
then the error below will show up:
```
 * satisfy_dependencies_for: Cannot satisfy the following dependencies for python-light:
 *	bluez-libs *
 * opkg_install_cmd: Cannot install package python-light.
```

This looks like a limitation in the design of package deps,
and maybe a misuse of conditional deps (i.e. PACKAGE_bluez-libs:bluez-libs).

So, to fix this, an idea we're adding an extra symbol
that enfoces installation of bluez-libs if selected.

We also need to add a way to disable bluetooth build
if PYTHON_BLUETOOTH_SUPPORT is de-selected.
Otherwise, bluetooth is installed and the socket
module is broken due to linker errors.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>